### PR TITLE
add wrapper for staged salesforce data endpoint

### DIFF
--- a/lib/HudAiClient.ts
+++ b/lib/HudAiClient.ts
@@ -57,6 +57,7 @@ export class HudAiClient {
     public relevantArticleCollateral: resources.RelevantArticleCollateralResource;
     public relevantArticles: resources.RelevantArticleResource;
     public sources: resources.SourceResource;
+    public stagedSalesforceData: resources.StagedSalesforceDataResource;
     public stockAlerts: resources.StockAlertResource;
     public textCorpora: resources.TextCorpusResource;
     public tweets: resources.TweetResource;
@@ -135,6 +136,7 @@ export class HudAiClient {
         this.relevantArticleCollateral = new resources.RelevantArticleCollateralResource(this.requestManager);
         this.relevantArticles = new resources.RelevantArticleResource(this.requestManager);
         this.sources = new resources.SourceResource(this.requestManager);
+        this.stagedSalesforceData = new resources.StagedSalesforceDataResource(this.requestManager);
         this.stockAlerts = new resources.StockAlertResource(this.requestManager);
         this.textCorpora = new resources.TextCorpusResource(this.requestManager);
         this.tweets = new resources.TweetResource(this.requestManager);

--- a/lib/entities/StagedSalesforceData.ts
+++ b/lib/entities/StagedSalesforceData.ts
@@ -1,5 +1,6 @@
 export interface StagedSalesforceData {
     id: string;
+    salesforceId: string;
     type: string;
     status: string;
     failedMessage: string;

--- a/lib/entities/StagedSalesforceData.ts
+++ b/lib/entities/StagedSalesforceData.ts
@@ -1,6 +1,5 @@
 export interface StagedSalesforceData {
     id: string;
-    userId: string;
     type: string;
     status: string;
     failedMessage: string;

--- a/lib/entities/StagedSalesforceData.ts
+++ b/lib/entities/StagedSalesforceData.ts
@@ -1,7 +1,8 @@
 export interface StagedSalesforceData {
     id: string;
-    salesforceId: string;
     type: string;
     status: string;
     failedMessage: string;
+    name: string;
+    website: string;
 }

--- a/lib/entities/StagedSalesforceData.ts
+++ b/lib/entities/StagedSalesforceData.ts
@@ -1,5 +1,6 @@
 export interface StagedSalesforceData {
     id: string;
+    userId: string;
     type: string;
     status: string;
     failedMessage: string;

--- a/lib/entities/StagedSalesforceData.ts
+++ b/lib/entities/StagedSalesforceData.ts
@@ -1,0 +1,7 @@
+export interface StagedSalesforceData {
+    id: string;
+    userId: string;
+    type: string;
+    status: string;
+    failedMessage: string;
+}

--- a/lib/entities/index.ts
+++ b/lib/entities/index.ts
@@ -24,6 +24,7 @@ export * from './Quote';
 export * from './RelevantArticle';
 export * from './RelevantArticleCollateral';
 export * from './Source';
+export * from './StagedSalesforceData';
 export * from './StockAlert';
 export * from './TextCorpus';
 export * from './Tweet';

--- a/lib/resources/StagedSalesforceData.ts
+++ b/lib/resources/StagedSalesforceData.ts
@@ -9,14 +9,14 @@ import { RequestManager } from '../RequestManager';
 import { StagedSalesforceData } from '../entities';
 
 export interface StagedSalesforceDataListAttributes extends HudAiListAttributes {
-    userId?: string;
+    userId: string;
     type?: string;
     status?: string;
 }
 
 export interface StagedSalesforceDataUpdateAttributes extends HudAiUpdateAttributes {
     id: string;
-    userId?: string;
+    userId: string;
     status: string;
     failedMessage?: string;
 }

--- a/lib/resources/StagedSalesforceData.ts
+++ b/lib/resources/StagedSalesforceData.ts
@@ -9,7 +9,6 @@ import { RequestManager } from '../RequestManager';
 import { StagedSalesforceData } from '../entities';
 
 export interface StagedSalesforceDataListAttributes extends HudAiListAttributes {
-    userId: string;
     type?: string;
     status?: string;
 }

--- a/lib/resources/StagedSalesforceData.ts
+++ b/lib/resources/StagedSalesforceData.ts
@@ -9,12 +9,14 @@ import { RequestManager } from '../RequestManager';
 import { StagedSalesforceData } from '../entities';
 
 export interface StagedSalesforceDataListAttributes extends HudAiListAttributes {
+    userId?: string;
     type?: string;
     status?: string;
 }
 
 export interface StagedSalesforceDataUpdateAttributes extends HudAiUpdateAttributes {
     id: string;
+    userId?: string;
     status: string;
     failedMessage?: string;
 }
@@ -40,7 +42,7 @@ export class StagedSalesforceDataResource extends Resource<
     public update(updateArgs: StagedSalesforceDataUpdateAttributes): Promise<StagedSalesforceData> {
         return this.makeRequest({
             method: 'PUT',
-            params: updateArgs,
+            data: updateArgs,
             url: `${this.basePath}/{id}`,
         });
     }

--- a/lib/resources/StagedSalesforceData.ts
+++ b/lib/resources/StagedSalesforceData.ts
@@ -1,0 +1,48 @@
+import * as Promise from 'bluebird';
+
+import {
+    HudAiListAttributes,
+    HudAiUpdateAttributes,
+    Resource
+} from '../utils/Resource';
+import { RequestManager } from '../RequestManager';
+import { StagedSalesforceData } from '../entities';
+
+export interface StagedSalesforceDataListAttributes extends HudAiListAttributes {
+    userId: string;
+    type?: string;
+    status?: string;
+}
+
+export interface StagedSalesforceDataUpdateAttributes extends HudAiUpdateAttributes {
+    id: string;
+    status: string;
+    failedMessage?: string;
+}
+
+export class StagedSalesforceDataResource extends Resource<
+    StagedSalesforceData,
+    StagedSalesforceDataListAttributes,
+    any,
+    StagedSalesforceDataUpdateAttributes
+> {
+    constructor(requestManager: RequestManager) {
+        super('/users/salesforce/staged', requestManager);
+    }
+
+    public list(listArgs: StagedSalesforceDataListAttributes): Promise<{ count: number, rows: StagedSalesforceData[] }> {
+        return this.makeRequest({
+            method: 'GET',
+            params: listArgs,
+            url: `${this.basePath}`,
+        });
+    }
+
+    public update(updateArgs: StagedSalesforceDataUpdateAttributes): Promise<StagedSalesforceData> {
+        return this.makeRequest({
+            method: 'PUT',
+            params: updateArgs,
+            url: `${this.basePath}/{id}`,
+        });
+    }
+}

--- a/lib/resources/StagedSalesforceData.ts
+++ b/lib/resources/StagedSalesforceData.ts
@@ -9,14 +9,14 @@ import { RequestManager } from '../RequestManager';
 import { StagedSalesforceData } from '../entities';
 
 export interface StagedSalesforceDataListAttributes extends HudAiListAttributes {
-    userId: string;
+    userId?: string;
     type?: string;
     status?: string;
 }
 
 export interface StagedSalesforceDataUpdateAttributes extends HudAiUpdateAttributes {
     id: string;
-    userId: string;
+    userId?: string;
     status: string;
     failedMessage?: string;
 }

--- a/lib/resources/index.ts
+++ b/lib/resources/index.ts
@@ -26,6 +26,7 @@ export { QuoteResource } from './Quote';
 export { RelevantArticleCollateralResource } from './RelevantArticleCollateral';
 export { RelevantArticleResource } from './RelevantArticle';
 export { SourceResource } from './Source';
+export { StagedSalesforceDataResource } from './StagedSalesforceData';
 export { StockAlertResource } from './StockAlert';
 export { TextCorpusResource } from './TextCorpus';
 export { TweetResource } from './Tweet';

--- a/test/HudAiClient.spec.ts
+++ b/test/HudAiClient.spec.ts
@@ -47,6 +47,7 @@ class HudAiClientSpec {
         expect(client.company).to.be.an.instanceOf(resources.CompanyResource);
         expect(client.domain).to.be.an.instanceOf(resources.DomainResource);
         expect(client.keyTerm).to.be.an.instanceOf(resources.KeyTermResource);
+        expect(client.stagedSalesforceData).to.be.an.instanceOf(resources.StagedSalesforceDataResource);
         expect(client.textCorpus).to.be.an.instanceOf(resources.TextCorpusResource);
         expect(client.user).to.be.an.instanceOf(resources.UserResource);
     }


### PR DESCRIPTION
This should go out after we update the users API with the corresponding staged Salesforce data endpoints. This adds a wrapper to our client library around that endpoint.