### PR TITLE
Add two missing entries for local score, and move optional localScore param from base class to extended class.

### DIFF
--- a/lib/entities/Article.ts
+++ b/lib/entities/Article.ts
@@ -23,7 +23,6 @@ export interface BasicArticle {
     tags?: BasicArticleTag[];
     imageUrl: string;
     importanceScore: number;
-    localScore?: number;
     linkUrl: string;
     sourceId: string;
     publishedAt: Date;
@@ -35,6 +34,7 @@ export interface BasicArticle {
 export interface ArticleSearchResult extends BasicArticle {
     groupId?: string;
     reactions?: object;
+    localScore?: number;
     authors: BasicAuthor[];
     companies: BasicArticleCompany[];
     keyTerms: BasicKeyTerm[];

--- a/lib/resources/Article.ts
+++ b/lib/resources/Article.ts
@@ -29,6 +29,7 @@ export interface ArticleCreateAttributes extends HudAiCreateAttributes {
     authors?: string[];
     imageUrl?: string;
     importanceScore?: number;
+    localScore?: number;
     linkUrl: string;
     publishedAt?: Date;
     rawDataUrl: string;
@@ -42,6 +43,7 @@ export interface ArticleUpdateAttributes extends HudAiUpdateAttributes {
     authors?: string[];
     imageUrl?: string;
     importanceScore?: number;
+    localScore?: number;
     linkUrl?: string;
     publishedAt?: Date;
     rawDataUrl?: string;


### PR DESCRIPTION
Related to https://github.com/FoundryAI/hud-ai-app/issues/669

More API updates to fix typescript compilation errors in _hud-ai-users-api_